### PR TITLE
Add configurable target pose test node

### DIFF
--- a/catkin_ws/src/barracuda_control/CMakeLists.txt
+++ b/catkin_ws/src/barracuda_control/CMakeLists.txt
@@ -14,6 +14,7 @@ geometry_msgs
 nav_msgs
 message_generation
 std_msgs
+tf
 )
 
 find_package(ct_core REQUIRED)
@@ -114,7 +115,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES barracuda_control
-  CATKIN_DEPENDS message_runtime geometry_msgs nav_msgs std_msgs
+  CATKIN_DEPENDS message_runtime geometry_msgs nav_msgs std_msgs tf
 #  DEPENDS system_lib
 )
 
@@ -176,10 +177,10 @@ target_link_libraries(lqr_node
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-# catkin_install_python(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+catkin_install_python(PROGRAMS
+  scripts/test_target_pose.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark executables for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html

--- a/catkin_ws/src/barracuda_control/config/lqr_params.yaml
+++ b/catkin_ws/src/barracuda_control/config/lqr_params.yaml
@@ -2,3 +2,13 @@ lqr:
   update_rate: 50
   Q: [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0]
   R: [1, 1, 1, 1, 1, 1]
+
+target_pose:
+  position:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  orientation:
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0

--- a/catkin_ws/src/barracuda_control/package.xml
+++ b/catkin_ws/src/barracuda_control/package.xml
@@ -38,6 +38,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf</depend>
   <depend>ct_core</depend>
   <depend>ct_rbd</depend>
   <depend>ct_optcon</depend>

--- a/catkin_ws/src/barracuda_control/scripts/test_target_pose.py
+++ b/catkin_ws/src/barracuda_control/scripts/test_target_pose.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""Publish a configurable target pose for the LQR node."""
+
+import rospy
+from nav_msgs.msg import Odometry
+from tf.transformations import quaternion_from_euler
+
+
+def publish_target_pose():
+    """Publish the target pose from parameters to ``target_odometry``."""
+    rospy.init_node("test_target_pose", anonymous=True)
+
+    position = rospy.get_param("target_pose/position", {})
+    orientation = rospy.get_param("target_pose/orientation", {})
+
+    odom_pub = rospy.Publisher("target_odometry", Odometry, queue_size=10)
+    rate = rospy.Rate(10)
+
+    odom_msg = Odometry()
+    odom_msg.pose.pose.position.x = position.get("x", 0.0)
+    odom_msg.pose.pose.position.y = position.get("y", 0.0)
+    odom_msg.pose.pose.position.z = position.get("z", 0.0)
+
+    q = quaternion_from_euler(
+        orientation.get("roll", 0.0),
+        orientation.get("pitch", 0.0),
+        orientation.get("yaw", 0.0),
+    )
+    odom_msg.pose.pose.orientation.x = q[0]
+    odom_msg.pose.pose.orientation.y = q[1]
+    odom_msg.pose.pose.orientation.z = q[2]
+    odom_msg.pose.pose.orientation.w = q[3]
+
+    while not rospy.is_shutdown():
+        odom_pub.publish(odom_msg)
+        rate.sleep()
+
+
+if __name__ == "__main__":
+    try:
+        publish_target_pose()
+    except rospy.ROSInterruptException:
+        pass
+


### PR DESCRIPTION
## Summary
- add Python node that publishes a configurable target pose for the LQR controller
- expose target pose parameters in `lqr_params.yaml`
- register node and tf dependency in the build system

## Testing
- `catkin_make` *(fails: command not found)*
- `apt-get install -y python3-catkin-tools` *(fails: unable to locate package)*
- `python3 -m py_compile src/barracuda_control/scripts/test_target_pose.py`


------
https://chatgpt.com/codex/tasks/task_e_68951af3d8d883308a1a3ae3b5916f52