### PR TITLE
Add 6-DOF PID controller for AUV

### DIFF
--- a/catkin_ws/src/barracuda_control/CMakeLists.txt
+++ b/catkin_ws/src/barracuda_control/CMakeLists.txt
@@ -149,6 +149,7 @@ ${hpipm_INCLUDE_DIRS}
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 add_executable(lqr_node src/lqr_node.cpp)
+add_executable(pid_node src/pid_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -159,6 +160,7 @@ add_executable(lqr_node src/lqr_node.cpp)
 ## Add cmake target dependencies of the executable
 ## same as for the library above
 add_dependencies(lqr_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(pid_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(lqr_node
@@ -166,6 +168,9 @@ target_link_libraries(lqr_node
   ct_core
   ct_optcon
   blasfeo
+)
+target_link_libraries(pid_node
+  ${catkin_LIBRARIES}
 )
 
 #############

--- a/catkin_ws/src/barracuda_control/config/lqr_params.yaml
+++ b/catkin_ws/src/barracuda_control/config/lqr_params.yaml
@@ -5,10 +5,10 @@ lqr:
 
 target_pose:
   position:
-    x: 0.0
+    x: 3.0
     y: 0.0
     z: 0.0
   orientation:
     roll: 0.0
     pitch: 0.0
-    yaw: 0.0
+    yaw: 3.14

--- a/catkin_ws/src/barracuda_control/config/pid_params.yaml
+++ b/catkin_ws/src/barracuda_control/config/pid_params.yaml
@@ -1,6 +1,6 @@
 pid:
   update_rate: 50
-  Kp: [1, 1, 1, 1, 1, 1]
+  Kp: [10, 10, 10, 10, 10, 10]
   Ki: [0, 0, 0, 0, 0, 0]
   Kd: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
@@ -12,4 +12,4 @@ target_pose:
   orientation:
     roll: 0.0
     pitch: 0.0
-    yaw: 0.0
+    yaw: 3.14

--- a/catkin_ws/src/barracuda_control/config/pid_params.yaml
+++ b/catkin_ws/src/barracuda_control/config/pid_params.yaml
@@ -1,0 +1,15 @@
+pid:
+  update_rate: 50
+  Kp: [1, 1, 1, 1, 1, 1]
+  Ki: [0, 0, 0, 0, 0, 0]
+  Kd: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+target_pose:
+  position:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  orientation:
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0

--- a/catkin_ws/src/barracuda_control/launch/start_thruster_manager.launch
+++ b/catkin_ws/src/barracuda_control/launch/start_thruster_manager.launch
@@ -37,7 +37,7 @@
   <!-- Thruster allocation matrix file path -->
   <arg name="tam_file" default="$(find barracuda_control)/config/TAM.yaml"/>
 
-  <rosparam command="load" file="$(find barracuda_control)/config/lqr_params.yaml" ns="$(arg model_name)"/>
+  <rosparam command="load" file="$(find barracuda_control)/config/pid_params.yaml" ns="$(arg model_name)"/>
 
   <include file="$(find uuv_thruster_manager)/launch/thruster_manager.launch">
     <arg name="model_name" value="$(arg model_name)"/>
@@ -50,5 +50,5 @@
     <arg name="tam_file" value="$(arg tam_file)"/>
    </include>
 
-   <node pkg="barracuda_control" name="lqr_node" type="lqr_node" ns="$(arg model_name)"/>
+   <node pkg="barracuda_control" name="pid_node" type="pid_node" ns="$(arg model_name)"/>
 </launch>

--- a/catkin_ws/src/barracuda_control/src/pid_node.cpp
+++ b/catkin_ws/src/barracuda_control/src/pid_node.cpp
@@ -115,8 +115,9 @@ private:
     bool setThrustZeroCallback(barracuda_control::SetThrustZero::Request& req,
                                barracuda_control::SetThrustZero::Response& res)
     {
-        thrust_zero_enabled_ = req.enable;
+        thrust_zero_enabled_ = req.enable_thrust_zero;
         res.success = true;
+        res.message = thrust_zero_enabled_ ? "Thrust zero enabled" : "Thrust zero disabled";
         return true;
     }
 

--- a/catkin_ws/src/barracuda_control/src/pid_node.cpp
+++ b/catkin_ws/src/barracuda_control/src/pid_node.cpp
@@ -24,7 +24,7 @@ public:
         T_map_robot_.setIdentity();
         T_map_target_.setIdentity();
         control_pub_ = nh_.advertise<geometry_msgs::Wrench>("thruster_manager/input", 1);
-        odom_sub_ = nh_.subscribe("odometry/filtered", 1, &PIDNode::odometryCallback, this);
+        odom_sub_ = nh_.subscribe("odometry_map/filtered", 1, &PIDNode::odometryCallback, this);
         target_sub_ = nh_.subscribe("target_odometry", 1, &PIDNode::targetCallback, this);
         thrust_zero_srv_ = nh_.advertiseService("set_thrust_zero", &PIDNode::setThrustZeroCallback, this);
     }

--- a/catkin_ws/src/barracuda_control/src/pid_node.cpp
+++ b/catkin_ws/src/barracuda_control/src/pid_node.cpp
@@ -1,0 +1,164 @@
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <geometry_msgs/Wrench.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+#include "barracuda_control/SetThrustZero.h"
+
+class PIDNode
+{
+public:
+    PIDNode(ros::NodeHandle& nh)
+        : nh_(nh), thrust_zero_enabled_(false), last_time_(ros::Time::now())
+    {
+        nh_.getParam("pid/update_rate", rate_);
+        std::vector<double> kp_vals(6), ki_vals(6), kd_vals(6);
+        getRosParamVector(nh_, "pid/Kp", kp_vals);
+        getRosParamVector(nh_, "pid/Ki", ki_vals);
+        getRosParamVector(nh_, "pid/Kd", kd_vals);
+        Kp_ = Eigen::Map<Eigen::Matrix<double,6,1>>(kp_vals.data()).asDiagonal();
+        Ki_ = Eigen::Map<Eigen::Matrix<double,6,1>>(ki_vals.data()).asDiagonal();
+        Kd_ = Eigen::Map<Eigen::Matrix<double,6,1>>(kd_vals.data()).asDiagonal();
+        e_integral_.setZero();
+        e_prev_.setZero();
+        T_map_robot_.setIdentity();
+        T_map_target_.setIdentity();
+        control_pub_ = nh_.advertise<geometry_msgs::Wrench>("thruster_manager/input", 1);
+        odom_sub_ = nh_.subscribe("odometry/filtered", 1, &PIDNode::odometryCallback, this);
+        target_sub_ = nh_.subscribe("target_odometry", 1, &PIDNode::targetCallback, this);
+        thrust_zero_srv_ = nh_.advertiseService("set_thrust_zero", &PIDNode::setThrustZeroCallback, this);
+    }
+
+    void run()
+    {
+        ros::Rate loop_rate(rate_);
+        while (ros::ok())
+        {
+            computeControl();
+            publishControl();
+            ros::spinOnce();
+            loop_rate.sleep();
+        }
+    }
+
+private:
+    void computeControl()
+    {
+        ros::Time now = ros::Time::now();
+        double dt = (now - last_time_).toSec();
+        last_time_ = now;
+        Eigen::Isometry3d T_error = T_map_robot_.inverse() * T_map_target_;
+        Eigen::Vector3d linear_error = T_error.translation();
+        Eigen::Quaterniond q_err(T_error.rotation());
+        q_err.normalize();
+        Eigen::AngleAxisd aa(q_err);
+        Eigen::Vector3d angular_error = aa.angle() * aa.axis();
+        Eigen::Matrix<double,6,1> e;
+        e << linear_error, angular_error;
+        if (dt > 0.0)
+        {
+            e_integral_ += e * dt;
+            e_derivative_ = (e - e_prev_) / dt;
+        }
+        e_prev_ = e;
+        control_ = Kp_ * e + Ki_ * e_integral_ + Kd_ * e_derivative_;
+    }
+
+    void publishControl()
+    {
+        geometry_msgs::Wrench msg;
+        if (thrust_zero_enabled_)
+        {
+            msg.force.x = msg.force.y = msg.force.z = 0.0;
+            msg.torque.x = msg.torque.y = msg.torque.z = 0.0;
+        }
+        else
+        {
+            msg.force.x = control_[0];
+            msg.force.y = control_[1];
+            msg.force.z = control_[2];
+            msg.torque.x = control_[3];
+            msg.torque.y = control_[4];
+            msg.torque.z = control_[5];
+        }
+        control_pub_.publish(msg);
+    }
+
+    void odometryCallback(const nav_msgs::Odometry::ConstPtr& msg)
+    {
+        Eigen::Quaterniond q(msg->pose.pose.orientation.w,
+                              msg->pose.pose.orientation.x,
+                              msg->pose.pose.orientation.y,
+                              msg->pose.pose.orientation.z);
+        q.normalize();
+        T_map_robot_.linear() = q.toRotationMatrix();
+        T_map_robot_.translation() = Eigen::Vector3d(
+            msg->pose.pose.position.x,
+            msg->pose.pose.position.y,
+            msg->pose.pose.position.z);
+    }
+
+    void targetCallback(const nav_msgs::Odometry::ConstPtr& msg)
+    {
+        Eigen::Quaterniond q(msg->pose.pose.orientation.w,
+                              msg->pose.pose.orientation.x,
+                              msg->pose.pose.orientation.y,
+                              msg->pose.pose.orientation.z);
+        q.normalize();
+        T_map_target_.linear() = q.toRotationMatrix();
+        T_map_target_.translation() = Eigen::Vector3d(
+            msg->pose.pose.position.x,
+            msg->pose.pose.position.y,
+            msg->pose.pose.position.z);
+    }
+
+    bool setThrustZeroCallback(barracuda_control::SetThrustZero::Request& req,
+                               barracuda_control::SetThrustZero::Response& res)
+    {
+        thrust_zero_enabled_ = req.enable;
+        res.success = true;
+        return true;
+    }
+
+    void getRosParamVector(ros::NodeHandle& nh, const std::string& name, std::vector<double>& vec)
+    {
+        if (!nh.getParam(name, vec))
+        {
+            vec.assign(6, 0.0);
+            ROS_WARN("Failed to load %s, using zeros", name.c_str());
+        }
+        else if (vec.size() != 6)
+        {
+            vec.resize(6, 0.0);
+            ROS_WARN("%s should have 6 elements", name.c_str());
+        }
+    }
+
+    ros::NodeHandle nh_;
+    ros::Publisher control_pub_;
+    ros::Subscriber odom_sub_;
+    ros::Subscriber target_sub_;
+    ros::ServiceServer thrust_zero_srv_;
+    int rate_;
+    bool thrust_zero_enabled_;
+    Eigen::Matrix<double,6,6> Kp_;
+    Eigen::Matrix<double,6,6> Ki_;
+    Eigen::Matrix<double,6,6> Kd_;
+    Eigen::Matrix<double,6,1> e_integral_;
+    Eigen::Matrix<double,6,1> e_derivative_;
+    Eigen::Matrix<double,6,1> e_prev_;
+    Eigen::Matrix<double,6,1> control_;
+    Eigen::Isometry3d T_map_robot_;
+    Eigen::Isometry3d T_map_target_;
+    ros::Time last_time_;
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "pid_node");
+    ros::NodeHandle nh;
+    PIDNode node(nh);
+    node.run();
+    return 0;
+}
+

--- a/catkin_ws/src/barracuda_control/src/pid_node.cpp
+++ b/catkin_ws/src/barracuda_control/src/pid_node.cpp
@@ -24,7 +24,7 @@ public:
         T_map_robot_.setIdentity();
         T_map_target_.setIdentity();
         control_pub_ = nh_.advertise<geometry_msgs::Wrench>("thruster_manager/input", 1);
-        odom_sub_ = nh_.subscribe("odometry_map/filtered", 1, &PIDNode::odometryCallback, this);
+        odom_sub_ = nh_.subscribe("odometry/filtered/global", 1, &PIDNode::odometryCallback, this);
         target_sub_ = nh_.subscribe("target_odometry", 1, &PIDNode::targetCallback, this);
         thrust_zero_srv_ = nh_.advertiseService("set_thrust_zero", &PIDNode::setThrustZeroCallback, this);
     }


### PR DESCRIPTION
## Summary
- Add matrix-based 6-DOF PID controller node that computes pose error in the body frame and publishes wrench commands
- Provide PID gain configuration file with update rate and default gains
- Build the new controller alongside the existing LQR node

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952207d3308330b0e0b4ade10e648a