### PR TITLE
Fix test odom frame and restore PID logging

### DIFF
--- a/catkin_ws/src/barracuda_control/scripts/test_target_pose.py
+++ b/catkin_ws/src/barracuda_control/scripts/test_target_pose.py
@@ -18,6 +18,7 @@ def publish_target_pose():
     rate = rospy.Rate(10)
 
     odom_msg = Odometry()
+    odom_msg.header.frame_id = "map"
     odom_msg.pose.pose.position.x = position.get("x", 0.0)
     odom_msg.pose.pose.position.y = position.get("y", 0.0)
     odom_msg.pose.pose.position.z = position.get("z", 0.0)
@@ -33,6 +34,7 @@ def publish_target_pose():
     odom_msg.pose.pose.orientation.w = q[3]
 
     while not rospy.is_shutdown():
+        odom_msg.header.stamp = rospy.Time.now()
         odom_pub.publish(odom_msg)
         rate.sleep()
 

--- a/catkin_ws/src/barracuda_control/src/pid_node.cpp
+++ b/catkin_ws/src/barracuda_control/src/pid_node.cpp
@@ -3,6 +3,7 @@
 #include <geometry_msgs/Wrench.h>
 #include <nav_msgs/Odometry.h>
 #include <ros/ros.h>
+#include <ros/console.h>
 #include "barracuda_control/SetThrustZero.h"
 
 class PIDNode
@@ -11,6 +12,10 @@ public:
     PIDNode(ros::NodeHandle& nh)
         : nh_(nh), thrust_zero_enabled_(false), last_time_(ros::Time::now())
     {
+        if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info))
+        {
+            ros::console::notifyLoggerLevelsChanged();
+        }
         nh_.getParam("pid/update_rate", rate_);
         std::vector<double> kp_vals(6), ki_vals(6), kd_vals(6);
         getRosParamVector(nh_, "pid/Kp", kp_vals);


### PR DESCRIPTION
## Summary
- set test target odometry's frame to `map` and stamp each message for RViz
- explicitly enable info-level logs in the PID node

## Testing
- `catkin_make` *(fails: command not found)*
- `apt-get install -y catkin` *(fails: Package 'catkin' has no installation candidate)*
- `g++ -fsyntax-only src/barracuda_control/src/pid_node.cpp` *(fails: Eigen/Dense: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689540dffcc0833098e49c723161a9e2